### PR TITLE
Suggestion to fix player check before deleting box

### DIFF
--- a/modules/rubble_town.sqf
+++ b/modules/rubble_town.sqf
@@ -156,6 +156,7 @@ local _time = diag_tickTime;
 local _finished = false;
 local _visited = false;
 local _isNear = true;
+local _foundPlayer = false;
 local _markers = [1,1,1,1];
 
 //[position,createMarker,setMarkerColor,setMarkerType,setMarkerShape,setMarkerBrush,setMarkerSize,setMarkerText,setMarkerAlpha]
@@ -189,7 +190,10 @@ while {!_finished} do {
 };
 
 while {_isNear} do {
-	{if (isPlayer _x && _x distance _box >= _distance) exitWith {_isNear = false};} count playableUnits;
+	_foundPlayer = false;
+	{if (isPlayer _x && _x distance _box <= _distance) exitWith {_foundPlayer = true;};} count playableUnits;
+	if (!_foundPlayer) then {_isNear = false;};
+	sleep 10;
 };
 
 deleteVehicle _box;


### PR DESCRIPTION
The issue is, unless ALL players are near the box, the current version will delete the loot. With my changes, it won't delete the box if ANY player is nearby. 
May be more efficient to use nearEntities but I felt lazy and figured to fix it would at least be nice.